### PR TITLE
fix underline nav selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Repo selected filter
 
 ## Recent Changes
 
+### Version 1.0.11 (11/19/2017)
+
+* fix underline nav selectors 
+
 ### Version 1.0.10 (9/23/2017)
 
 * Increase sub tab specificity. Fixes [issue #9](https://github.com/StylishThemes/GitHub-Selected-Tab-Color/issues/9).

--- a/github-selected-tab-color.css
+++ b/github-selected-tab-color.css
@@ -16,7 +16,8 @@
   }
   body .repo-filterer .repo-filter.filter-selected,
   body .filter-selected,
-  body .underline-nav-item.selected,
+  body .UnderlineNav-item:hover,
+  body .UnderlineNav-item.selected,
   body .sub-nav ul a.active {
     border-bottom-color: /*[[base-color]]*/ #4183C4 !important;
   }

--- a/github-selected-tab-color.css
+++ b/github-selected-tab-color.css
@@ -1,5 +1,5 @@
 @-moz-document domain("github.com") {
- /*! GitHub Selected Tab Color v1.0.10 (9/23/2017) *//*
+ /*! GitHub Selected Tab Color v1.0.11 (11/19/2017) *//*
  * https://github.com/StylishThemes/GitHub-Selected-Tab-Color
  * https://userstyles.org/styles/130386/
  * License: https://creativecommons.org/licenses/by-sa/4.0/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-selected-tab-color",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "GitHub  theme for Stylish",
   "license": "CC-BY-SA-4.0",
   "repository": "StylishThemes/GitHub-Selected-Tab-Color",


### PR DESCRIPTION
My guess is some GitHub update must have broken this recently, just noticed it today.

![tabs](https://user-images.githubusercontent.com/31389848/32990553-1d5b58c8-cd23-11e7-9a06-f4a29e43cb1a.gif)

FF 57
Win 10

Bumped version and added changelog separately just in case, if not needed let me know and Ill remove it.