### PR TITLE
fix: dont show .UnderlneNav-item as white when not :focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Repo selected filter
 
 ## Recent Changes
 
+### Version 1.0.13 (07/18/2018)
+
+* Prevent .UnderlineNav-item from showing as white while not :focus.
+
 ### Version 1.0.12 (07/05/2018)
 
 * Add support for features page bottom navigation.

--- a/github-selected-tab-color.css
+++ b/github-selected-tab-color.css
@@ -1,5 +1,5 @@
 @-moz-document domain("github.com") {
- /*! GitHub Selected Tab Color v1.0.12 (07/05/2018) *//*
+ /*! GitHub Selected Tab Color v1.0.13 (07/18/2018) *//*
  * https://github.com/StylishThemes/GitHub-Selected-Tab-Color
  * https://userstyles.org/styles/130386/
  * License: https://creativecommons.org/licenses/by-sa/4.0/
@@ -15,10 +15,11 @@
   }
   body .repo-filterer .repo-filter.filter-selected,
   body .filter-selected,
-  body .UnderlineNav-item:hover,
-  body .UnderlineNav-item.selected,
   body .sub-nav ul a.active,
-  body .IconNav-item.selected {
+  body .IconNav-item.selected,
+  body .UnderlineNav-item:focus,
+  body .UnderlineNav-item:hover,
+  body .UnderlineNav-item.selected {
     border-bottom-color: /*[[base-color]]*/ #4183C4 !important;
   }
   body .menu-item.selected:before {

--- a/github-selected-tab-color.user.css
+++ b/github-selected-tab-color.user.css
@@ -1,6 +1,6 @@
 /* ==UserStyle==
 @name        GitHub Selected Tab Color
-@version     v1.0.12
+@version     v1.0.13
 @description Add a custom selected tab color to GitHub
 @namespace   github.com/StylishThemes
 @author      StylishThemes <https://github.com/StylishThemes>
@@ -22,10 +22,11 @@
   }
   body .repo-filterer .repo-filter.filter-selected,
   body .filter-selected,
-  body .UnderlineNav-item:hover,
-  body .UnderlineNav-item.selected,
   body .sub-nav ul a.active,
-  body .IconNav-item.selected {
+  body .IconNav-item.selected,
+  body .UnderlineNav-item:focus,
+  body .UnderlineNav-item:hover,
+  body .UnderlineNav-item.selected {
     border-bottom-color: base-color !important;
   }
   body .menu-item.selected:before {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-selected-tab-color",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "GitHub  theme for Stylish",
   "license": "CC-BY-SA-4.0",
   "repository": "StylishThemes/GitHub-Selected-Tab-Color",


### PR DESCRIPTION
When moving mouse away before its loaded the underline nav may show as white, this prevents/fixes that.
![focus](https://user-images.githubusercontent.com/31389848/42877759-9fc8b414-8a82-11e8-956a-395000a320fb.gif)

Also bumped revision and added changelog, GitHub wont let tag commits in a PR so that is up to you.
